### PR TITLE
chore: revert AMP script classList workaround

### DIFF
--- a/bertytech/assets/js/amp-faq.js
+++ b/bertytech/assets/js/amp-faq.js
@@ -3,24 +3,12 @@ faqs.forEach(faq => {
   const q = faq.querySelector('.block-faq-q');
   const a = faq.querySelector('.block-faq-a');
 
-  // q.addEventListener('click', function(e) {
-  //   a.classList.toggle('show');
-  //   q.classList.toggle('collapsed');
-  //   q.setAttribute('aria-expanded', !q.classList.contains('collapsed'));
-  // })
-
-  // temporary workaround because of this issue: https://github.com/berty/www.berty.tech/issues/97
   q.addEventListener('click', function(e) {
     closeAllOtherFaqs(faq);
-    if (q.classList.contains('collapsed')) {
-      a.setAttribute('class', 'block-faq-a show');
-      q.setAttribute('class', 'block-faq-q');
-    } else {
-      a.setAttribute('class', 'block-faq-a');
-      q.setAttribute('class', 'block-faq-q collapsed');
-    }
+    a.classList.toggle('show');
+    q.classList.toggle('collapsed');
     q.setAttribute('aria-expanded', !q.classList.contains('collapsed'));
-  });
+  })
 })
 
 function closeAllOtherFaqs(currentFaq) {
@@ -28,7 +16,7 @@ function closeAllOtherFaqs(currentFaq) {
     if (faq == currentFaq) return;
     const q = faq.querySelector('.block-faq-q');
     const a = faq.querySelector('.block-faq-a');
-    a.setAttribute('class', 'block-faq-a');
-    q.setAttribute('class', 'block-faq-q collapsed');
+    a.classList.remove('show');
+    q.classList.add('collapsed');
   })  
 }

--- a/bertytech/assets/js/amp-navbar.js
+++ b/bertytech/assets/js/amp-navbar.js
@@ -16,10 +16,7 @@ function openDropdown(dropdown) {
   const link = dropdown.querySelector('.nav-link');
   const menu = dropdown.querySelector('.dropdown-menu');
 
-  // temporary workaround because of this issue: https://github.com/berty/www.berty.tech/issues/97
-  menu.setAttribute('class', 'dropdown-menu show');
-  // menu.classList.add('show');
-
+  menu.classList.add('show');
   link.setAttribute('aria-expanded', true);
 }
 
@@ -27,9 +24,6 @@ function closeDropdown(dropdown) {
   const link = dropdown.querySelector('.nav-link');
   const menu = dropdown.querySelector('.dropdown-menu');
 
-  // temporary workaround because of this issue: https://github.com/berty/www.berty.tech/issues/97
-  menu.setAttribute('class', 'dropdown-menu');
-  // menu.classList.remove('show');
-  
+  menu.classList.remove('show');
   link.setAttribute('aria-expanded', false);
 }


### PR DESCRIPTION
Reverting back the workaround for the amp-script issue, which is now fixed by https://github.com/ampproject/worker-dom/pull/879