### PR TITLE
fix: signal messenger comparison - maybe was confused with Status 

### DIFF
--- a/bertytech/content/compare-table-apps/signal.md
+++ b/bertytech/content/compare-table-apps/signal.md
@@ -3,11 +3,11 @@ title: Signal
 weight: -70
 open_source: true
 no_runtime_fee: true
-no_purchase_fee: Partially
+no_purchase_fee: true
 distributed: false
 decentralized: "?"
-no_phone_required: true
-anonymous: true
+no_phone_required: false
+anonymous: false
 e2ee: true
 offline_messaging: false
 multi_device: Partially


### PR DESCRIPTION
I think I confused Signal with Status messenger when changing the entry.
At least I fix the "phone requirement"  now which also requires the anonymous entry to change.