### PR TITLE
feat: Adding go-tor-transport to projects.

### DIFF
--- a/bertytech/assets/css/style.scss
+++ b/bertytech/assets/css/style.scss
@@ -27,8 +27,8 @@ $color-green-light: #D3F8F2;
 $color-purple-light:#472e91;
 
 /* Anonymity's color */
-$color-cyan:#00E4EB;
-$color-cyan-light:#C7E4EB;
+$color-cyan:#00BAE8;
+$color-cyan-light:#C3F7F4;
 $color-tor:#7D4698; /* Tor's text palette. */
 
 $color-blue-90: #525BEC; /* blue 90% for backgrounds */

--- a/bertytech/assets/css/style.scss
+++ b/bertytech/assets/css/style.scss
@@ -26,6 +26,11 @@ $color-yellow-light:#FFF0D4; /* yellow 23% */
 $color-green-light: #D3F8F2;
 $color-purple-light:#472e91;
 
+/* Anonymity's color */
+$color-cyan:#00E4EB;
+$color-cyan-light:#C7E4EB;
+$color-tor:#7D4698; /* Tor's text palette. */
+
 $color-blue-90: #525BEC; /* blue 90% for backgrounds */
 
 /* other variables */
@@ -1528,6 +1533,16 @@ a.tag-card{
   &.green {
     color:$color-green;
     background-color:$color-green-light;
+  }
+  &.cyan {
+    color:$color-cyan;
+    background-color:$color-cyan-light;
+  }
+  &.tor {
+    color:$color-tor; /* Using Color on white text with a border because any kind of lightened of tor's palette is ugly. */
+    border-color:$color-tor;
+    border:solid;
+    border-width:thin;
   }
 }
 /* TAG */

--- a/bertytech/content/docs/assets/index.md
+++ b/bertytech/content/docs/assets/index.md
@@ -6,7 +6,7 @@ color: black
 open: true
 menu:
     repos:
-        weight: 6
+        weight: 7
 ---
 
 # Assets

--- a/bertytech/content/docs/go-tor-transport/index.md
+++ b/bertytech/content/docs/go-tor-transport/index.md
@@ -1,0 +1,27 @@
+---
+title: Go-Tor-Transport
+description: Go version of Peer-to-Peer Databases for the Decentralized Web
+icon: fab fa-github
+color: black
+display_nav: false
+ttags:  <span class="tag blue">Go</span><span class="tag blue">Libp2p</span><span class="tag cyan">Anonymity</span><span class="tag tor">Tor</span>
+open: true
+menu:
+    repos:
+        weight: 6
+---
+
+# Go-Tor-Transport
+
+**Go and C tor builtin transport for libp2p.**
+
+## Introduction
+
+[go-tor-transport](https://github.com/berty/go-tor-transport) is a transport proving access to an libp2p network through the tor network.
+
+To do that the code mainly uses [go-libtor](https://github.com/ipsn/go-libtor) to provide a go linking of the [Tor's](https://www.torproject.org/) node.
+
+## Source code
+Source code is available on [github](https://github.com/berty/go-tor-transport).
+
+<a class="btn btn-bty btn-grack" href="https://github.com/berty/go-tor-transport"><i class="fab fa-github"></i>berty/go-tor-transport</a>

--- a/bertytech/content/docs/go-tor-transport/index.md
+++ b/bertytech/content/docs/go-tor-transport/index.md
@@ -1,6 +1,6 @@
 ---
 title: Go-Tor-Transport
-description: Go version of Peer-to-Peer Databases for the Decentralized Web
+description: Go and C tor binary builtin transport for libp2p.
 icon: fab fa-github
 color: black
 display_nav: false
@@ -13,13 +13,16 @@ menu:
 
 # Go-Tor-Transport
 
-**Go and C tor builtin transport for libp2p.**
+**Go and C tor binary builtin transport for libp2p, aiming to provide anonymised access to the libp2p network.**
+
 
 ## Introduction
 
 [go-tor-transport](https://github.com/berty/go-tor-transport) is a transport proving access to an libp2p network through the tor network.
 
 To do that the code mainly uses [go-libtor](https://github.com/ipsn/go-libtor) to provide a go linking of the [Tor's](https://www.torproject.org/) node.
+
+So at the start it either connects to a node running in system or start his own one embed in the binary, so usage can be seemless as possible.
 
 ## Source code
 Source code is available on [github](https://github.com/berty/go-tor-transport).

--- a/bertytech/content/docs/yolo/index.md
+++ b/bertytech/content/docs/yolo/index.md
@@ -7,7 +7,7 @@ display_nav: false
 open: true
 menu:
     repos:
-        weight: 7
+        weight: 8
 ---
 
 # Yolo


### PR DESCRIPTION
Result :
![Capture d’écran du 2020-09-07 00-11-39](https://user-images.githubusercontent.com/24391983/92336248-dc50c000-f09e-11ea-9288-9a911c35690f.png)
I've choosen theses cyans for Anonymity because it's an in beetween the color of `Open Source` and the classic `blue`.
(The idea would be to add the same badge on I2P if it gets done). I think it could be also switched to yellow or red if the goal is to keep the current palette (not blue it would be too much blue in one card).
The weight I've just tried all positions in the 2nd and 3th lines and this is best one (it's makes a corner of `Go-*-*` in top right corner.).