### PR TITLE
fix: absolute amp-script paths

### DIFF
--- a/bertytech/layouts/faq/list.html
+++ b/bertytech/layouts/faq/list.html
@@ -12,7 +12,9 @@
   <div class="container">
 
     <section class="section-faq">
-      <amp-script class="row" layout="container" src="{{ (resources.Get `js/amp-faq.js`).RelPermalink }}">
+      {{ $res := resources.Get "js/amp-faq.js" }}
+      {{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+      <amp-script class="row" layout="container" src="{{ $src }}">
         <div class="col-12">
           {{ range sort .Pages "Params.id" }}
           {{ partial "block_faq" . }}

--- a/bertytech/layouts/jobs/single.html
+++ b/bertytech/layouts/jobs/single.html
@@ -22,7 +22,9 @@
         {{ .Site.Params.jobsWorkingAtBerty | markdownify }}
         <br />
         <div class="buttons">
-          <amp-script layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+          {{ $res := resources.Get "js/obs-email.js" }}
+          {{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+          <amp-script layout="flex-item" src="{{ $src }}">
             <a class="btn btn-bty btn-blue sendto-{{ `jobs@berty.tech` | base64Encode }}"><i class="fal fa-pencil-alt"></i>Apply to this offer</a>
           </amp-script>
         </div>

--- a/bertytech/layouts/partials/block_action_request_talk.html
+++ b/bertytech/layouts/partials/block_action_request_talk.html
@@ -1,4 +1,6 @@
-<amp-script layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+{{ $res := resources.Get "js/obs-email.js" }}
+{{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+<amp-script layout="flex-item" src="{{ $src }}">
 	<a class="block block-action bg-blue bg-gradient bg-question sendto-{{ `hello@berty.tech` | base64Encode }} sendsubject-{{ `Request a talk` | base64Encode }}">
 		<h4><i class="fal fa-presentation left"></i>Request a talk<i class="far fa-chevron-right right"></i></h4>
 	</a><!-- /.block -->

--- a/bertytech/layouts/partials/block_action_suggest_question.html
+++ b/bertytech/layouts/partials/block_action_suggest_question.html
@@ -1,4 +1,6 @@
-<amp-script layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+{{ $res := resources.Get "js/obs-email.js" }}
+{{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+<amp-script layout="flex-item" src="{{ $src }}">
 	<a class="block block-action bg-blue bg-gradient bg-question sendto-{{ `hello@berty.tech` | base64Encode }} sendsubject-{{ `New FAQ question` | base64Encode }}">
 		<h4><i class="fal fa-question-circle left"></i>Suggest a question<i class="far fa-chevron-right right"></i></h4>
 	</a><!-- /.block -->

--- a/bertytech/layouts/partials/navbar.html
+++ b/bertytech/layouts/partials/navbar.html
@@ -10,7 +10,9 @@
         </button>
         <div class="collapse navbar-collapse justify-content-end" id="navbar-links">
 
-          <amp-script layout="container" src="{{ (resources.Get `js/amp-navbar.js`).RelPermalink }}">
+          {{ $res := resources.Get "js/amp-navbar.js" }}
+          {{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+          <amp-script layout="container" src="{{ $src }}">
             <ul class="navbar-nav">
               <li class="nav-item dropdown"> 
                   <a class="nav-link" href="#" id="d-difference" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/bertytech/layouts/shortcodes/display_section_contact_secure.html
+++ b/bertytech/layouts/shortcodes/display_section_contact_secure.html
@@ -9,7 +9,9 @@
 			<p><strong>If you wish to enhance email security</strong>, use PGP/GPG encryption technology:</p>
 			<div class="block-key">
 				<span class="left"><i class="far fa-envelope"></i>Email</span>
-				<amp-script class="right" layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+				{{ $res := resources.Get "js/obs-email.js" }}
+        {{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+				<amp-script class="right" layout="flex-item" src="{{ $src }}">
 					<span class="obsinner-{{ `secure@berty.tech` | base64Encode }}"></span>
 				</amp-script>
 			</div>
@@ -25,7 +27,9 @@
 
 			<div class="block-key">
 				<span class="left"><i class="far fa-envelope"></i>Email</span>
-				<amp-script class="right" layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+				{{ $res := resources.Get "js/obs-email.js" }}
+        {{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+				<amp-script class="right" layout="flex-item" src="{{ $src }}">
 					<span class="obsinner-{{ `bertytech@protonmail.com` | base64Encode }}"></span>
 				</amp-script>
 			</div>

--- a/bertytech/layouts/shortcodes/display_section_press.html
+++ b/bertytech/layouts/shortcodes/display_section_press.html
@@ -20,7 +20,9 @@
     {{- end }}
   </div><!-- /.col -->
   <div class="col-lg-4 col-md-6">
-    <amp-script layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+    {{ $res := resources.Get "js/obs-email.js" }}
+    {{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+    <amp-script layout="flex-item" src="{{ $src }}">
     <div class= "block block-contact text-center">
       <h3>Contact</h3>
       <a class="h4 obsinner-{{ `press@berty.tech` | base64Encode }} sendto-{{ `press@berty.tech` | base64Encode }}"></a>

--- a/bertytech/layouts/shortcodes/display_section_social.html
+++ b/bertytech/layouts/shortcodes/display_section_social.html
@@ -16,7 +16,9 @@
       </a>
     </div>
     
-    <amp-script class="col-lg-3 col-md-6" layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+    {{ $res := resources.Get "js/obs-email.js" }}
+    {{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
+    <amp-script class="col-lg-3 col-md-6" layout="flex-item" src="{{ $src }}">
       <a class="block block-value bg-white sendto-{{ `hello@berty.tech` | base64Encode }}">
         <div class="block-value-icon c-blue"><i class="fal fa-envelope"></i></div>
         <div class="block-value-text">Email us at&nbsp;<br/> <span class="c-blue to-text obsinner-{{ `hello@berty.tech` | base64Encode }}"></span></div>

--- a/bertytech/layouts/shortcodes/obscure.html
+++ b/bertytech/layouts/shortcodes/obscure.html
@@ -1,5 +1,7 @@
+{{ $res := resources.Get "js/obs-email.js" }}
+{{ $src := cond (eq (getenv "BERTY_IPFS") "true") $res.RelPermalink $res.Permalink }} 
 <span style="display: inline-flex;">
-<amp-script layout="flex-item" src="{{ (resources.Get `js/obs-email.js` | minify | fingerprint).RelPermalink }}">
+<amp-script layout="flex-item" src="{{ $src }}">
   <span class="obsinner-{{ .Get 0 | base64Encode }}">-</span>
 </amp-script>
 </span>


### PR DESCRIPTION
PR #150 broke the regular site because amp-script does not allow using relative src paths. This PR reverts it back to absolute paths, but when building for IPFS, it uses relative paths