### PR TITLE
Improve translation comparison

### DIFF
--- a/bertytech/layouts/partials/head.html
+++ b/bertytech/layouts/partials/head.html
@@ -1,3 +1,4 @@
+{{ $scratch := newScratch }}
 {{ $.Scratch.Set `pageTitle` (cond (eq .Title .Site.Title) (.Site.Title) ((print .Title " &middot; " .Site.Title) | safeHTML)) }}
 
 <!--
@@ -34,8 +35,8 @@
 {{ $.Scratch.Set "currentPage" . }}
 {{ $.Scratch.Set "isEnglishCopy" false }}
 {{ $englishSite := .Sites.First }}
-{{ $englishPageContent := "" }}
-<!-- If current page is not English -->
+{{ $ignoreCompareKeys := slice "date" "lastmod" }}
+
 {{ if ne .Lang "en" }}
   <!-- Get English page -->
   {{ range .Translations}}
@@ -43,20 +44,29 @@
       {{ $.Scratch.Set "englishPage" . }}
     {{ end }}
   {{ end }}
-{{ end }}
-<!-- Get English file's content -->
-{{ if ($.Scratch.Get "englishPage") }}
-  {{ if ($.Scratch.Get "englishPage").File }}
-    {{ $englishPageContent = readFile ($.Scratch.Get "englishPage").File }}
+
+  <!-- Filter out params of current page and add to string to compare -->
+  {{ $scratch.Set "currentPageCompare" (print "content=" .Content) }}
+  {{ range $key, $value := .Params}}
+    {{ if (not (in $ignoreCompareKeys $key)) }}
+      {{ $scratch.Add "currentPageCompare" (print $key "=" $value) }}
+    {{ end }}
   {{ end }}
-{{ end }}
-<!-- Compare English file's content -->
-{{ if .File }}
-{{ $.Scratch.Set "isEnglishCopy" (eq (readFile .File) $englishPageContent) }}
-{{ end }}
-<!-- Set language to "en" if it's just a copy -->
-{{ if ($.Scratch.Get "isEnglishCopy") }}
-  {{ $.Scratch.Set "currentPage" ($.Scratch.Get "englishPage") }}
+
+  <!-- Filter out params of english page and add to string to compare -->
+  {{ $scratch.Set "englishPageCompare" (print "content=" ($.Scratch.Get "englishPage").Content) }}
+  {{ range $key, $value := ($.Scratch.Get "englishPage").Params }}
+    {{ if (not (in $ignoreCompareKeys $key)) }}
+      {{ $scratch.Add "englishPageCompare" (print $key "=" $value) }}
+    {{ end }}
+  {{ end }}
+
+  <!-- Compare if params and content are the same between the english and translated version -->
+  {{ $.Scratch.Set "isEnglishCopy" (eq ($scratch.Get "currentPageCompare") ($scratch.Get "englishPageCompare") ) }}
+  {{ if ($.Scratch.Get "isEnglishCopy") }}
+    {{ $.Scratch.Set "currentPage" ($.Scratch.Get "englishPage") }}
+  {{ end }}
+
 {{ end }}
 
 <!doctype html>

--- a/bertytech/layouts/partials/head.html
+++ b/bertytech/layouts/partials/head.html
@@ -46,7 +46,7 @@
   {{ end }}
 
   <!-- Filter out params of current page and add to string to compare -->
-  {{ $scratch.Set "currentPageCompare" (print "content=" .Content) }}
+  {{ $scratch.Set "currentPageCompare" "" }}
   {{ range $key, $value := .Params}}
     {{ if (not (in $ignoreCompareKeys $key)) }}
       {{ $scratch.Add "currentPageCompare" (print $key "=" $value) }}
@@ -54,7 +54,7 @@
   {{ end }}
 
   <!-- Filter out params of english page and add to string to compare -->
-  {{ $scratch.Set "englishPageCompare" (print "content=" ($.Scratch.Get "englishPage").Content) }}
+  {{ $scratch.Set "englishPageCompare" "" }}
   {{ range $key, $value := ($.Scratch.Get "englishPage").Params }}
     {{ if (not (in $ignoreCompareKeys $key)) }}
       {{ $scratch.Add "englishPageCompare" (print $key "=" $value) }}


### PR DESCRIPTION
This PR changes the logic which compares if a content file is translated or not.

- It ignores frontmatter keys "date" "lastmod", because these are probably always different between translations
- It does not compare .Content (only frontmatter). This is because for example the contact page (https://deploy-preview-181--bertytech.netlify.app/fr/contact) would otherwise been considered translated since it has the newsletter section translated.