### PR TITLE
Auto add translations script

### DIFF
--- a/bertytech/package-lock.json
+++ b/bertytech/package-lock.json
@@ -3584,6 +3584,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     }
   }
 }

--- a/bertytech/package.json
+++ b/bertytech/package.json
@@ -20,7 +20,8 @@
     "postcss-import": "^12.0.1",
     "postcss-purifycss": "^1.1.0",
     "postcss-replace": "^1.1.2",
-    "webp-converter": "^2.2.3"
+    "webp-converter": "^2.2.3",
+    "yaml": "^1.10.0"
   },
   "browserslist": [
     "> 1%"

--- a/bertytech/pre-build.sh
+++ b/bertytech/pre-build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-# node ./replace-remote-md-images.js
+node ./scripts/create-translation-files.js

--- a/bertytech/scripts/create-translation-files.js
+++ b/bertytech/scripts/create-translation-files.js
@@ -28,6 +28,7 @@ const createTranslatedFiles = async (filepath) => {
     );
 
     if (!fs.existsSync(langFile)) {
+      console.log(`Created missing translation file: ${langFile}`);
       fs.copyFileSync(filepath, langFile);
     }
   });

--- a/bertytech/scripts/create-translation-files.js
+++ b/bertytech/scripts/create-translation-files.js
@@ -1,0 +1,36 @@
+const YAML = require("yaml");
+const path = require("path");
+const fs = require("fs");
+const glob = require("glob");
+
+// This script creates missing translation files
+// Example index.fr.md
+
+const configFile = path.resolve(__dirname, "../config.yaml");
+const configContent = fs.readFileSync(configFile, "utf8");
+const config = YAML.parse(configContent);
+
+const defaultLanguage = config.DefaultContentLanguage;
+const languages = Object.keys(config.languages).filter(
+  (lang) => lang !== defaultLanguage
+);
+
+const files = glob.sync(path.join(__dirname, "../content", "**/*.md"), {
+  ignore: path.join(__dirname, "../content", "**/*.*.md"),
+});
+
+const createTranslatedFiles = async (filepath) => {
+  const extension = path.extname(filepath);
+  languages.forEach((language) => {
+    const langFile = path.join(
+      path.dirname(filepath),
+      `${path.basename(filepath, extension)}.${language}${extension}`
+    );
+
+    if (!fs.existsSync(langFile)) {
+      fs.copyFileSync(filepath, langFile);
+    }
+  });
+};
+
+Promise.all(files.map(createTranslatedFiles));

--- a/bertytech/scripts/package-lock.json
+++ b/bertytech/scripts/package-lock.json
@@ -80,6 +80,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     }
   }
 }

--- a/bertytech/scripts/package.json
+++ b/bertytech/scripts/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "glob": "^7.1.6"
+    "glob": "^7.1.6",
+    "yaml": "^1.10.0"
   }
 }


### PR DESCRIPTION
Automatically generates missing translation files by copying the English version on pre-build. No need to manually add the languages, as the script reads the enabled languages from Hugo's config.yaml file.