### PR TITLE
chore: Add issue templates for bug, question and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,0 +1,91 @@
+name: "Bug report"
+description: Report a bug found while using the Berty web site (not the Berty app).
+labels: ["bug"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: What browser are you using to view the web site?
+      options:
+        - Firefox
+        - Chrome
+        - Brave
+        - Edge
+        - Safari
+        - Other (please specify below)
+    validations:
+      required: true
+  - type: input
+    id: browser-version
+    attributes:
+      label: Browser version
+      description: What is the version of your browser?
+      placeholder: e.g. 112.0.5615.49
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      description: What OS are you seeing the problem on?
+      options:
+        - iOS
+        - Android
+        - Linux
+        - macOS
+        - Windows
+        - Other (please specify below)
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: OS version
+      description: What is the version of the OS you are using?
+      placeholder: e.g. iOS 15.4 or Android 11.0 or Ubuntu 20.04.4
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: What device are you using?
+      placeholder: e.g. macOS 13.3.1 or iPhone 12 Pro Max
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+       1. Navigate to the page ...
+       2. Click on drop down ...
+       3. Click item ...
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: A description including screenshots, stack traces, debug logs, etc.
+      placeholder: Currently ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Please provide what would be your expectation to happen.
+      placeholder: In this situation, Berty should ...
+  - type: textarea
+    id: other
+    attributes:
+      label: Other
+      placeholder: Any other details?

--- a/.github/ISSUE_TEMPLATE/feature_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yml
@@ -1,0 +1,48 @@
+name: "Feature request"
+description: Suggest an idea for the Berty web site (not the Berty app).
+labels: [":rocket: feature-request"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for this feature request.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: What browser do you intend for this feature request?
+      options:
+        - Any browser
+        - Firefox
+        - Chrome
+        - Brave
+        - Edge
+        - Safari
+        - Other (please specify below)
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature request
+      description: Provide a detailed description of the change or addition you are proposing.
+      placeholder: There should be ...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this change important to you? How would you use it? How can it benefit other users?
+      placeholder: This feature request is important because ...
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Possible implementation
+      description: Not obligatory, but suggest an idea for implementing addition or change.
+      placeholder: This feature could be implemented by ...

--- a/.github/ISSUE_TEMPLATE/question_template.yml
+++ b/.github/ISSUE_TEMPLATE/question_template.yml
@@ -1,0 +1,48 @@
+name: "Question"
+description: Ask a question about using Berty web site (not the Berty app).
+labels: ["question"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Asking a question, not reporting a bug
+      description: If your question is "Why don't I get what I expect?" and you think it is a bug, then please open a Bug Report at https://github.com/berty/www.berty.tech/issues/new/
+      options:
+      - label: This question is not about a bug
+        required: true
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for your question.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: What browser are you using to view the web site?
+      options:
+        - Firefox
+        - Chrome
+        - Brave
+        - Edge
+        - Safari
+        - Other (please specify below)
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Provide your question with enough detail that it is helpful to anyone reading the question (maybe years later).
+      placeholder: How do I ...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Is it a general question about the design and goals of the Berty web site, or about how to view it (or some other context)?
+      placeholder: This is a question about ...
+    validations:
+      required: true


### PR DESCRIPTION
We want an new issue to automatically have the labels "bug", "question" or "feature request" similar to our other projects. This helps in the issue management workflow.