### PR TITLE
chore: In the question template, fix the new issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/question_template.yml
+++ b/.github/ISSUE_TEMPLATE/question_template.yml
@@ -5,7 +5,7 @@ body:
   - type: checkboxes
     attributes:
       label: Asking a question, not reporting a bug
-      description: If your question is "Why don't I get what I expect?" and you think it is a bug, then please open a Bug Report at https://github.com/berty/www.berty.tech/issues/new/
+      description: If your question is "Why don't I get what I expect?" and you think it is a bug, then please open a Bug Report at https://github.com/berty/www.berty.tech/issues/new/choose
       options:
       - label: This question is not about a bug
         required: true


### PR DESCRIPTION
This updates PR #375 . The link to the new issue page needs to have "choose" like the template in all the other repositories.