### PR TITLE
fix: In README, remove private link to staff members (not useful)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ _TODO: generic contribute intro_
 
 For more context read [This blog post](https://berty.tech/blog/berty-translation).
 
-## Maintainers
-
-The [berty-staff](https://github.com/orgs/berty/teams/staff) team.
-
 ## License
 
 © [Berty Technologies](https://berty.tech) | Code is licensed with the [MIT](./LICENSE) License. Except as noted, other content licensed [CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/us/).


### PR DESCRIPTION
The list of staff members on GitHub is private. Only staff members can see it. So not much use in having a link to it, and it's confusing to have a broken link. Besides, public users can already click on the repository "Contributors".

Resolves #351