### PR TITLE
399 bertys broken link

### DIFF
--- a/bertytech/content/features/index.ar.md
+++ b/bertytech/content/features/index.ar.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.cn.md
+++ b/bertytech/content/features/index.cn.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.eo.md
+++ b/bertytech/content/features/index.eo.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.es.md
+++ b/bertytech/content/features/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.hi.md
+++ b/bertytech/content/features/index.hi.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.id-id.md
+++ b/bertytech/content/features/index.id-id.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.ka.md
+++ b/bertytech/content/features/index.ka.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.md
+++ b/bertytech/content/features/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.pl.md
+++ b/bertytech/content/features/index.pl.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.pt-br.md
+++ b/bertytech/content/features/index.pt-br.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.pt.md
+++ b/bertytech/content/features/index.pt.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.sl.md
+++ b/bertytech/content/features/index.sl.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.te.md
+++ b/bertytech/content/features/index.te.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.uk.md
+++ b/bertytech/content/features/index.uk.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/features/index.zh.md
+++ b/bertytech/content/features/index.zh.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+subtitle: Privacy-first messaging application built on top of the protocol Wesh Network.
 hclass: bg-blue gradient bg-features
 image: "berty_features.png"
 #menu:

--- a/bertytech/content/messenger/index.ar.md
+++ b/bertytech/content/messenger/index.ar.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.cn.md
+++ b/bertytech/content/messenger/index.cn.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.eo.md
+++ b/bertytech/content/messenger/index.eo.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.es.md
+++ b/bertytech/content/messenger/index.es.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.fr.md
+++ b/bertytech/content/messenger/index.fr.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.hi.md
+++ b/bertytech/content/messenger/index.hi.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.id-id.md
+++ b/bertytech/content/messenger/index.id-id.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.ka.md
+++ b/bertytech/content/messenger/index.ka.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.md
+++ b/bertytech/content/messenger/index.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty.app
+        link: /features
         text: Berty Messenger
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty Messenger
-        link: https://berty.app
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.pl.md
+++ b/bertytech/content/messenger/index.pl.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.pt-br.md
+++ b/bertytech/content/messenger/index.pt-br.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.pt.md
+++ b/bertytech/content/messenger/index.pt.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.ru.md
+++ b/bertytech/content/messenger/index.ru.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.sl.md
+++ b/bertytech/content/messenger/index.sl.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.te.md
+++ b/bertytech/content/messenger/index.te.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.uk.md
+++ b/bertytech/content/messenger/index.uk.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/content/messenger/index.zh.md
+++ b/bertytech/content/messenger/index.zh.md
@@ -4,7 +4,7 @@ subtitle: Berty messenger is a privacy-first messaging application built on top 
 header:
     image: icon_messenger.svg
     button:
-        link: https://berty-handles.netlify.app/vision
+        link: /features
         text: Berty handles
 hclass: bg-blue gradient bg-messenger
 image: "berty_about.png"
@@ -17,6 +17,6 @@ body:
         - Berty, your next unstoppable messenger, no matter what.
     button:
         text: Berty handles
-        link: https://berty-handles.netlify.app/vision
+        link: /features
     image: img_messenger.png
 ---

--- a/bertytech/layouts/shortcodes/display_section_features.html
+++ b/bertytech/layouts/shortcodes/display_section_features.html
@@ -3,50 +3,66 @@
 <div id="hero" class="container">
   <section class="section-about top">
       <div class="row text-center">
-
-        <div class="col-md-6 mb-5 mb-md-0">
-          <div class="block bg-white h-100">
-            <div class="d-flex flex-column py-0">
-              <div class="order-2 order-md-1">
-                <h3 class="mb-2">
-                  <strong>No Face, No Name, No Number</strong>
-                </h3>
-                <h4>No SIM card, No Internet</h4>
-                <p>Berty is a messenger that doesn’t require any of your personal data or network connection.</p>
-              </div>
-    
-              <div class="order-1 order-md-2 mb-4 mb-md-0 mt-md-4">
-                {{ $img := .Page.Resources.GetMatch "noface-noname.png" }}
-                {{ partial "img" (dict "ctx" . "src" $img.RelPermalink "width" "200" "height" "62") }}
-              </div>
-            </div>
-          </div>
+        <div class="col-md-12 mb-5 mb-md-0 justify-content-end">
+          <a href="https://play.google.com/store/apps/details?id=tech.berty.android" target="_blank" rel="noopener noreferrer">
+            <img src="/img/google-play-logo.png" alt="Google play store" width="200">
+          </a>
+          <a href="https://apps.apple.com/tt/app/berty/id1535500412" target="_blank" rel="noopener noreferrer">
+            <img src="/img/app-store-logo.png" alt="Apple store" width="200">
+          </a>
         </div>
-  
-        <div class="col-md-6 mb-5 mb-md-0">
-          <div class="block bg-white h-100">
-            <div class="d-flex flex-column py-0">
-              <div class="order-2 order-md-1">
-                <h3 class="mb-2">
-                  <strong>Safety by Default</strong>
-                </h3>
-                <h4>Privacy by Design</h4>
-                <p>All conversations are encrypted with end-to-end encryption, in a fully distributed network.</p>
-              </div>
-    
-              <div class="order-1 order-md-2 mb-4 mb-md-0 mt-md-4">
-                {{ $img := .Page.Resources.GetMatch "secure-encryption.png" }}
-                {{ partial "img" (dict "ctx" . "src" $img.RelPermalink "width" "200" "height" "62") }}
-              </div>
-            </div>
-          </div>
-        </div>
-
       </div>
   </section>
 </div>
 
+
 <section id="subscribe-1" class="section-features-detail section-hwbg bg-grey">
+  <div class="container">
+    <div class="row text-center">
+
+      <div class="col-md-6 mb-5 mb-md-0">
+        <div class="block bg-white h-100">
+          <div class="d-flex flex-column py-0">
+            <div class="order-2 order-md-1">
+              <h3 class="mb-2">
+                <strong>No Face, No Name, No Number</strong>
+              </h3>
+              <h4>No SIM card, No Internet</h4>
+              <p>Berty is a messenger that doesn’t require any of your personal data or network connection.</p>
+            </div>
+
+            <div class="order-1 order-md-2 mb-4 mb-md-0 mt-md-4">
+              {{ $img := .Page.Resources.GetMatch "noface-noname.png" }}
+              {{ partial "img" (dict "ctx" . "src" $img.RelPermalink "width" "200" "height" "62") }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-md-6 mb-5 mb-md-0">
+        <div class="block bg-white h-100">
+          <div class="d-flex flex-column py-0">
+            <div class="order-2 order-md-1">
+              <h3 class="mb-2">
+                <strong>Safety by Default</strong>
+              </h3>
+              <h4>Privacy by Design</h4>
+              <p>All conversations are encrypted with end-to-end encryption, in a fully distributed network.</p>
+            </div>
+
+            <div class="order-1 order-md-2 mb-4 mb-md-0 mt-md-4">
+              {{ $img := .Page.Resources.GetMatch "secure-encryption.png" }}
+              {{ partial "img" (dict "ctx" . "src" $img.RelPermalink "width" "200" "height" "62") }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div><!--  /.row -->
+  </div><!-- /.container -->
+</section>
+
+<section id="subscribe-1" class="section-features-detail section-hwbg bg-white">
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-md-12 text-center">
@@ -79,7 +95,7 @@
   </div><!-- /.container -->
 </section>
 
-<section id="bluetooth" class="section-features-detail bg-white">
+<section id="bluetooth" class="section-features-detail bg-grey">
   <div class="container">
     <div class="row align-items-center justify-content-between">
       <div class="col-lg-5 col-md-6 order-2 order-md-1">
@@ -109,7 +125,7 @@
       </div><!-- /.col -->
       <div class="col-md-5">
         <div class="block-mixed-text">
-          <h3>Available on any device <span>or system: iOS, Android, Windows, Linux</span></h3>
+          <h3>Available on any device<span>: iOS, Android</span></h3>
         </div><!-- /.block-mixed-text -->
       </div><!-- /.col -->
     </div><!--  /.row -->


### PR DESCRIPTION
I'm proposing to redirect the flow to the Features page until we have the new Berty's Landing Page.
I also added the App Store links on the page.
This PR is a fix for #399.

<img width="1441" alt="Screenshot 2023-10-02 at 15 19 36" src="https://github.com/berty/www.berty.tech/assets/689440/3c4a1e00-1c61-4645-ad78-19bc453e4a16">
