### PR TITLE
Removing FreshChat

### DIFF
--- a/bertytech/layouts/partials/footer.html
+++ b/bertytech/layouts/partials/footer.html
@@ -52,15 +52,15 @@
 								<li><a href="https://berty-tech.myshopify.com/">Boutique</a></li>
 								<li><a href="https://assets.berty.tech/">Assets</a></li>
 							</ul>
-						</div><!-- /.col -->		
+						</div><!-- /.col -->
 					</div><!-- /.row -->
 				</div><!-- /.col -->
 			</div><!-- /.row -->
 			<div class="row row-bottom">
 				<div class="col-lg-8 col-md-7 footer-legal">
-					<small>Berty™ is a registered trademark © 2018-2023 Berty Technologies - All right reserved - 
+					<small>Berty™ is a registered trademark © 2018-2023 Berty Technologies - All right reserved -
 						{{ $url := relLangURL "/terms" }}
-						<a href="{{ cond $is_404 (absURL $url) $url }}">Terms & Conditions</a> - 
+						<a href="{{ cond $is_404 (absURL $url) $url }}">Terms & Conditions</a> -
 						{{ $url := relLangURL "/privacy-policy" }}
 						<a href="{{ cond $is_404 (absURL $url) $url }}">Privacy Policy</a>
 					</small>
@@ -84,18 +84,6 @@
 {{ $js := slice $jQuery $bootstrap $slick $particles $lazySizes $qrcode $main | resources.Concat "bundle.js" | minify | fingerprint }}
 <script type="text/javascript" src="{{ $js.RelPermalink }}"></script>
 {{ end }}
-
-<!-- fresh chat -->
-<script>
-  function initFreshChat() {
-    window.fcWidget.init({
-      token: "26cd6e22-0e7f-4bc3-9636-54beac8cb39b",
-      host: "https://wchat.eu.freshchat.com"
-    });
-  }
-  function initialize(i,t){var e;i.getElementById(t)?initFreshChat():((e=i.createElement("script")).id=t,e.async=!0,e.src="https://wchat.eu.freshchat.com/js/widget.js",e.onload=initFreshChat,i.head.appendChild(e))}function initiateCall(){initialize(document,"Freshdesk Messaging-js-sdk")}window.addEventListener?window.addEventListener("load",initiateCall,!1):window.attachEvent("load",initiateCall,!1);
-</script>
-<!-- end fresh chat -->
 
 <!-- 100% privacy friendly analytics -->
 <script async defer src="https://sa.berty.tech/latest.js"></script>

--- a/bertytech/layouts/partials/script.html
+++ b/bertytech/layouts/partials/script.html
@@ -13,17 +13,5 @@
 <script type="text/javascript" src="{{ $js.RelPermalink }}"></script>
 {{ end }}
 
-<!-- fresh chat -->
-<script>
-  function initFreshChat() {
-    window.fcWidget.init({
-      token: "26cd6e22-0e7f-4bc3-9636-54beac8cb39b",
-      host: "https://wchat.eu.freshchat.com"
-    });
-  }
-  function initialize(i,t){var e;i.getElementById(t)?initFreshChat():((e=i.createElement("script")).id=t,e.async=!0,e.src="https://wchat.eu.freshchat.com/js/widget.js",e.onload=initFreshChat,i.head.appendChild(e))}function initiateCall(){initialize(document,"Freshdesk Messaging-js-sdk")}window.addEventListener?window.addEventListener("load",initiateCall,!1):window.attachEvent("load",initiateCall,!1);
-</script>
-<!-- end fresh chat -->
-
 </body>
 </html>


### PR DESCRIPTION
Removing the FreshChat widget because Berty doesn't have the hands at the moment to give chat support to its users.

<img width="424" alt="Screenshot 2023-10-02 at 15 40 33" src="https://github.com/berty/www.berty.tech/assets/689440/820967b4-6ab8-4412-8030-e95bb960fe8f">


