### PR TITLE
chore: removing AMP validator to fix CI

### DIFF
--- a/bertytech/Makefile
+++ b/bertytech/Makefile
@@ -31,7 +31,6 @@ prod-build:
 	hugo --gc $(HUGO_OPTS)
 	./go-get.sh
 	./post-build.sh
-	node ./validate-amp.js
 
 .PHONY: prod-build-ipfs
 prod-build-ipfs:


### PR DESCRIPTION
This PR is a quick fix for CI/CD. 
Another solution could involve upgrading HUGO + Nodejs version which could be harder.