### PR TITLE
chore: Features page: Remove the Android warning

### DIFF
--- a/bertytech/layouts/shortcodes/display_section_features.html
+++ b/bertytech/layouts/shortcodes/display_section_features.html
@@ -4,9 +4,6 @@
   <section class="section-about">
       <div class="row text-center">
         <div class="col-md-12 mb-5 mb-md-0 justify-content-end">
-          <div style="background-color: red; color: white; padding: 2px; margin-bottom: 32px; margin-top: 60px;">
-            Warning: the Android app (including apk) is currently unavailable for download and use due to an ongoing essential security update.
-          </div>
           <a href="https://play.google.com/store/apps/details?id=tech.berty.android" target="_blank" rel="noopener noreferrer">
             <img src="/img/google-play-logo.png" alt="Google play store" width="200">
           </a>


### PR DESCRIPTION
We have a new Android release. I think we can remove this warning on the [Features page](https://berty.tech/features).

<img width="981" height="376" alt="image" src="https://github.com/user-attachments/assets/7a454ee2-2027-4101-a9a1-71569922b6a5" />
